### PR TITLE
host-configuration: split README and put the purpose of the section i…

### DIFF
--- a/host-configuration/docs/0_Abstract.md
+++ b/host-configuration/docs/0_Abstract.md
@@ -1,0 +1,6 @@
+The purpose of this section is to help developers to natively develop and debug
+AGL microservices. Thanks to OBS, packages for debian/ubuntu, openSUSE and
+fedora distributions are available and can be installed on developer host.
+
+At first hand, the idea is to easily handle native development of AGL services
+and at second hand to run the same services on targets/boards.

--- a/host-configuration/docs/README.md
+++ b/host-configuration/docs/README.md
@@ -7,13 +7,6 @@ stack for the connected car.
 
 ![Automotive grade linux screenshot](pictures/Automotive_grade_linux.png)
 
-The purpose of this section is to help developers to natively develop and debug
-AGL microservices. Thanks to OBS, packages for debian/ubuntu, openSUSE and
-fedora distributions are available and can be installed on developer host.
-
-At first hand, the idea is to easily handle native development of AGL services
-and at second hand to run the same services on targets/boards.
-
 | *Meta* | *Data* |
 | -- | -- |
 | **Title** | {{ config.title }} |

--- a/host-configuration/docs/SUMMARY.md
+++ b/host-configuration/docs/SUMMARY.md
@@ -2,6 +2,7 @@
 
 * [Document revisions](0-Doc-Revisions.md)
 
+* [Abstract](0_Abstract.md)
 * [Prerequisites](1_Prerequisites.md)
 * [AGL Application Framework Installation](2_AGL_Application_Framework.md)
 * [AGL XDS Installation.md](3_AGL_XDS.md)

--- a/host-configuration/mkdocs.yml
+++ b/host-configuration/mkdocs.yml
@@ -3,6 +3,7 @@ theme: readthedocs
 docs_dir: docs
 pages:
 - 'Document revisions' : '0-Doc-Revisions.md'
+- '0. Abstract': '0_Abstract.md'
 - '1. Prequisites': '1_Prerequisites.md'
 - '2. AGL Application Framework Installation': '2_AGL_Application_Framework.md'
 - '3. AGL XDS Installation.md': '3_AGL_XDS.md'


### PR DESCRIPTION
…nto 0_Abstract.md

The idea is to get this part into generated pdf files and into official
AGL documentation.

Signed-off-by: Clément Bénier <clement.benier@iot.bzh>