### PR TITLE
Building Microservice Natively: Added new files

### DIFF
--- a/host-configuration/docs/0-build-microservice-overview.md
+++ b/host-configuration/docs/0-build-microservice-overview.md
@@ -1,0 +1,55 @@
+# Overview
+
+You can develop Microservices on your native Linux machine quickly
+by following the workflow in this section.
+This workflow takes advantage of RPM or Debian packages,which are available
+through the
+[OpenSUSE Build Service (OBS)](https://build.opensuse.org/).
+You can install these
+[packages](https://build.opensuse.org/project/subprojects/isv:LinuxAutomotive)
+and bypass the
+[Yocto Project](https://yoctoproject.org) build cycles described in the
+"[Developing an AGL Image](../../../../../../getting_started/en/dev/reference/image-workflow-intro.html)" section.
+
+Using this workflow, you can start to code, execute, and debug Microservice
+bindings directly on your host.  This flow works for many cases for which
+no specific hardware is required, or when you can plug hardware directly
+into your native Linux host's USB port such as a Controller Area Network
+([CAN](https://en.wikipedia.org/wiki/CAN_bus)) bus Adapter or a Media
+Oriented Systems Transport
+([MOST](https://en.wikipedia.org/wiki/MOST_Bus)) Controller.
+
+The following figure and list overview the Microservice Native Development
+process.
+You can learn about the steps in the process by reading through the
+remaining sections.
+
+<center><img src="pictures/microservice-workflow-native.png"></center>
+
+1. **Verify Your Build Host:**
+   Make sure you have a native Linux host.
+   For the example used in this section (i.e. `helloworld-service`), be sure your
+   Linux distribution is a recent version of Debian, Ubuntu, OpenSUSE, or Fedora.
+
+2. **Download and Install AGL Packages:**
+   Download and install the
+   [near-zero](https://en.wikipedia.org/wiki/Zero_Install) packages
+   from the OBS.
+
+3. **Install the Binder Daemon:**
+   Install the Binder Daemon, which is a part of the
+   [AGL Application Framework (AFM)](../../../../../../apis_services/en/dev/reference/af-main/0-introduction.html).
+   The daemon allows you to connect applications to required services.
+
+4. **Get Your Source Files:**
+   For this section, you clone the `helloworld-service` binding repository.
+   You also need to make sure you have some other required packages to build
+   that specific binding.
+
+5. **Build and Run Your Service Natively (Optional Tool Use):**
+   Build your binding on your Linux host using native tools.
+   Once the binding is built, you can run it to make sure it functions
+   as expected.
+   
+   Optionally use extra tools once your binding is building and running
+   smoothly in the native environment.

--- a/host-configuration/docs/1-verify-build-host.md
+++ b/host-configuration/docs/1-verify-build-host.md
@@ -1,0 +1,29 @@
+# 1. Verify Your Build Host
+
+In order to build a Microservice binding natively, you need to be using a
+supported Linux distribution.
+In general, a recent version of Debian, Ubuntu, OpenSUSE, and Fedora works.
+Following is a specific list of supported distributions:
+
+* [Debian](https://www.debian.org/releases/) 9.0
+* [Ubuntu](https://wiki.ubuntu.com/Releases) 16.04, 16.10, 17.10, and 18.04
+* [OpenSUSE](https://en.opensuse.org/openSUSE:Roadmap) Leap 15.0 and Tumbleweed
+* [Fedora](https://fedoraproject.org/wiki/Releases) 27, 28, 29, and Rawhide.
+
+Exporting the `DISTRO` environment variable defines the distribution.
+Following are examples:
+
+**WRITER NOTE:** Email is out to the group asking about these string values.
+How does a developer know what value to use?
+What are the values for supported OpenSUSE and Fedora distributions?
+
+
+```bash
+export DISTRO="Debian_9.0"
+export DISTRO="xUbuntu_16.04"
+export DISTRO="xUbuntu_16.10"
+export DISTRO="xUbuntu_17.10"
+export DISTRO="xUbuntu_18.04"
+```
+
+Set the `DISTRO` environment appropriately.

--- a/host-configuration/docs/1-verify-build-host.md
+++ b/host-configuration/docs/1-verify-build-host.md
@@ -13,11 +13,6 @@ Following is a specific list of supported distributions:
 Exporting the `DISTRO` environment variable defines the distribution.
 Following are examples:
 
-**WRITER NOTE:** Email is out to the group asking about these string values.
-How does a developer know what value to use?
-What are the values for supported OpenSUSE and Fedora distributions?
-
-
 ```bash
 export DISTRO="Debian_9.0"
 export DISTRO="xUbuntu_16.04"

--- a/host-configuration/docs/2-download-packages.md
+++ b/host-configuration/docs/2-download-packages.md
@@ -38,15 +38,6 @@ section for information on how to set this variable.
 
 ## Install the Repository
 
-**WRITER NOTES:** Code seemed to work.
-I don't know for sure though.
-Have email out to the group asking for a look at the output.
-See the Pastebin https://pastebin.com/KTt3563B.
-It looks to me like if you run this more than once, you are concatanating the
-two lines into that `/etc/apt/sources.list.d/AGL.list` file again and again.
-Not sure if that is what you want.
-If you run it once you get the following output:
-
 ```
 Hit:1 https://deb.nodesource.com/node_10.x xenial InRelease
 Hit:2 https://download.docker.com/linux/ubuntu xenial InRelease
@@ -135,10 +126,6 @@ dnf repolist --all | grep AGL
 ```
 
 ## Switching Between Repositories
-
-**WRITER NOTES:** I don't understand the following information.
-Looks like there is missing output.
-Plus, there is no real explanation of the output and what it means.
 
 The commands in the previous section showed you how to install the packages
 from a specific repository and how to verify whether or not the packages

--- a/host-configuration/docs/2-download-packages.md
+++ b/host-configuration/docs/2-download-packages.md
@@ -1,0 +1,243 @@
+# 2. Download Packages
+
+Different repositories exist for different AGL releases.
+You need to download and install the packages based on your version
+of AGL.
+
+## Set the `REVISION` Environment Variable
+
+All the packages reside in repositories managed by the
+[OpenSUSE Build Service (OBS)](https://build.opensuse.org/).
+You can see the packages
+[here](https://build.opensuse.org/project/subprojects/isv:LinuxAutomotive#).
+
+Currently, support exists for the following AGL releases:
+
+* ElectricEel
+* FunkyFlounder
+* GrumpyGuppy
+* Master
+
+You need to set the `REVISION` environment variable to the AGL release you
+are using.
+For this example, set and export `REVISION` as "Funky Flounder".
+
+```bash
+$ export REVISION=FunkyFlounder
+```
+For additional details about OBS, see
+[LinuxAutomotive page on OBS](https://build.opensuse.org/project/show/isv:LinuxAutomotive).
+
+## Make Sure Your `DISTRO` Environment Variable is Set
+
+The `DISTRO` environment variable needs to be correctly set for your
+Linux distribution.
+See the
+"[Verify Your Build Host](./1-verify-build-host.html)"
+section for information on how to set this variable.
+
+## Install the Repository
+
+**WRITER NOTES:** Code seemed to work.
+I don't know for sure though.
+Have email out to the group asking for a look at the output.
+See the Pastebin https://pastebin.com/KTt3563B.
+It looks to me like if you run this more than once, you are concatanating the
+two lines into that `/etc/apt/sources.list.d/AGL.list` file again and again.
+Not sure if that is what you want.
+If you run it once you get the following output:
+
+```
+Hit:1 https://deb.nodesource.com/node_10.x xenial InRelease
+Hit:2 https://download.docker.com/linux/ubuntu xenial InRelease
+Hit:3 http://security.ubuntu.com/ubuntu xenial-security InRelease
+Hit:4 http://us.archive.ubuntu.com/ubuntu xenial InRelease
+Ign:5 http://download.opensuse.org/repositories/isv:/LinuxAutomotive:/AGL_FunkyFlounder/xUbuntu_16.04 ./ InRelease
+Hit:6 http://us.archive.ubuntu.com/ubuntu xenial-updates InRelease
+Hit:7 http://download.opensuse.org/repositories/isv:/LinuxAutomotive:/AGL_FunkyFlounder/xUbuntu_16.04 ./ Release
+Hit:8 http://us.archive.ubuntu.com/ubuntu xenial-backports InRelease
+Reading package lists... Done
+```
+
+Not sure why you get the `Ign` on line 5.
+I guess InRelease does not exist.
+
+If you don't have a `/etc/apt/sources.list.d/AGL.list` file to even start with,
+and you run through the whole thing, you get the following output:
+
+```
+$ sudo apt-get update
+Hit:1 https://deb.nodesource.com/node_10.x xenial InRelease
+Hit:2 https://download.docker.com/linux/ubuntu xenial InRelease
+Hit:3 http://us.archive.ubuntu.com/ubuntu xenial InRelease
+Get:4 http://us.archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
+Get:5 http://security.ubuntu.com/ubuntu xenial-security InRelease [107 kB]
+Ign:6 http://download.opensuse.org/repositories/isv:/LinuxAutomotive:/AGL_FunkyFlounder/xUbuntu_16.04 ./ InRelease
+Hit:7 http://download.opensuse.org/repositories/isv:/LinuxAutomotive:/AGL_FunkyFlounder/xUbuntu_16.04 ./ Release
+Get:9 http://us.archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
+Get:10 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [902 kB]
+Fetched 1,225 kB in 1s (803 kB/s)
+Reading package lists... Done
+```
+
+
+Following are example commands that show how to install the package repository
+based on various values of `DISTRO` and `REVISION`:
+
+### Ubuntu and "FunkyFlounder"
+
+```bash
+export REVISION=FunkyFlounder
+export DISTRO="xUbuntu_18.04"
+wget -O - http://download.opensuse.org/repositories/isv:/LinuxAutomotive:/AGL_${REVISION}/${DISTRO}/Release.key | sudo apt-key add -
+sudo bash -c "cat >> /etc/apt/sources.list.d/AGL.list <<EOF
+#AGL
+deb http://download.opensuse.org/repositories/isv:/LinuxAutomotive:/AGL_${REVISION}/${DISTRO}/ ./
+EOF"
+sudo apt-get update
+```
+
+You can see the installed repository using the following command:
+
+```bash
+cat /etc/apt/sources.list.d/AGL.list
+```
+
+### OpenSUSE and "FunkyFlounder"
+
+```bash
+export DISTRO="OpenSUSE_lEAP_42.3"
+export REVISION=FunkyFlounder
+source /etc/os-release; export DISTRO=$(echo $PRETTY_NAME | sed "s/ /_/g")
+sudo zypper ar http://download.opensuse.org/repositories/isv:/LinuxAutomotive:/AGL_${REVISION}/${DISTRO}/isv:LinuxAutomotive:AGL_${REVISION}.repo
+sudo zypper --gpg-auto-import-keys ref
+```
+
+You can see the installed repository using the following command:
+
+```bash
+zypper repos | grep AGL
+```
+
+### Fedora and "FunkyFlounder"
+
+```bash
+export DISTRO="Fedora_28"
+export REVISION=FunkyFlounder
+source /etc/os-release ; export DISTRO="${NAME}_${VERSION_ID}"
+sudo wget -O /etc/yum.repos.d/isv:LinuxAutomotive:AGL_${REVISION}.repo http://download.opensuse.org/repositories/isv:/LinuxAutomotive:/AGL_${REVISION}/${DISTRO}/isv:LinuxAutomotive:AGL_${REVISION}.repo
+```
+
+You can see the installed repository using the following command:
+
+```bash
+dnf repolist --all | grep AGL
+```
+
+## Switching Between Repositories
+
+**WRITER NOTES:** I don't understand the following information.
+Looks like there is missing output.
+Plus, there is no real explanation of the output and what it means.
+
+The commands in the previous section showed you how to install the packages
+from a specific repository and how to verify whether or not the packages
+are enabled or disabled.
+You can switch between different repositories.
+You must disable your current AGL repository and then enable the repository
+designated for the switch.
+
+Following is an example for Debian distributions:
+
+### Example for Debian distro
+
+Suppose you are on "master" and you want the "ElectricEel" AGL revision.
+
+```bash
+export OLDR=Master
+export NEWR=ElectricEel
+sudo sed -i "s/${OLDR}/${NEWR}/g" /etc/apt/sources.list.d/AGL.list
+sudo apt-get update
+```
+
+### Example for openSuse distro
+
+```bash
+#  | Alias                               | Name                                                                                      | Enabled | GPG Check | Refresh
+---+-------------------------------------+-------------------------------------------------------------------------------------------+---------+-----------+--------
+ 1 | Atom                                | Atom Editor                                                                               | Yes     | (r ) Yes  | No
+ 2 | code                                | Visual Studio Code                                                                        | Yes     | (r ) Yes  | No
+ 3 | http-ftp.uni-erlangen.de-e3cebb6d   | Packman Repository                                                                        | Yes     | (r ) Yes  | Yes
+ 4 | isv_LinuxAutomotive_AGL_ElectricEel | isv:LinuxAutomotive:AGL_ElectricEel (openSUSE_Leap_15.0)                                  | Yes     | (r ) Yes  | No
+ 5 | isv_LinuxAutomotive_AGL_Master      | Automotive Grade Linux Application Development tools - master branch (openSUSE_Leap_15.0) | No      | ----      | ----
+ 6 | openSUSE-Leap-15.0-1                | openSUSE-Leap-15.0-1                                                                      | No      | ----      | ----
+ 7 | repo-debug                          | openSUSE-Leap-15.0-Debug                                                                  | No      | ----      | ----
+ 8 | repo-debug-non-oss                  | openSUSE-Leap-15.0-Debug-Non-Oss                                                          | No      | ----      | ----
+ 9 | repo-debug-update                   | openSUSE-Leap-15.0-Update-Debug                                                           | No      | ----      | ----
+10 | repo-debug-update-non-oss           | openSUSE-Leap-15.0-Update-Debug-Non-Oss                                                   | No      | ----      | ----
+11 | repo-non-oss                        | openSUSE-Leap-15.0-Non-Oss                                                                | Yes     | (r ) Yes  | Yes
+12 | repo-oss                            | openSUSE-Leap-15.0-Oss                                                                    | Yes     | (r ) Yes  | Yes
+13 | repo-source                         | openSUSE-Leap-15.0-Source                                                                 | No      | ----      | ----
+14 | repo-source-non-oss                 | openSUSE-Leap-15.0-Source-Non-Oss                                                         | No      | ----      | ----
+15 | repo-update                         | openSUSE-Leap-15.0-Update                                                                 | Yes     | (r ) Yes  | Yes
+16 | repo-update-non-oss                 | openSUSE-Leap-15.0-Update-Non-Oss                                                         | Yes     | (r ) Yes  | Yes
+```
+
+Now, you want your "master" repository enabled.
+In the above output, the "ElectricEel" repository is at the fourth line
+and the "master" repository is at the fifth line.
+Thus, enter the following:
+
+```bash
+$ sudo zypper mr -d 4 && sudo zypper mr -e 5
+Repository 'isv_LinuxAutomotive_AGL_ElectricEel' has been successfully disabled.
+Repository 'isv_LinuxAutomotive_AGL_Master' has been successfully enabled.
+sudo zypper refresh
+```
+
+**NOTE:** In the previous command, the "-d" option is used for "disable" and the
+"-e" option is used for "enable".
+
+Following are the results:
+
+
+```bash
+#  | Alias                               | Name                                                                                      | Enabled | GPG Check | Refresh
+---+-------------------------------------+-------------------------------------------------------------------------------------------+---------+-----------+--------
+ 1 | Atom                                | Atom Editor                                                                               | Yes     | (r ) Yes  | No
+ 2 | code                                | Visual Studio Code                                                                        | Yes     | (r ) Yes  | No
+ 3 | http-ftp.uni-erlangen.de-e3cebb6d   | Packman Repository                                                                        | Yes     | (r ) Yes  | Yes
+ 4 | isv_LinuxAutomotive_AGL_ElectricEel | isv:LinuxAutomotive:AGL_ElectricEel (openSUSE_Leap_15.0)                                  | No      | ----      | ----
+ 5 | isv_LinuxAutomotive_AGL_Master      | Automotive Grade Linux Application Development tools - master branch (openSUSE_Leap_15.0) | Yes     | (r ) Yes  | No
+ 6 | openSUSE-Leap-15.0-1                | openSUSE-Leap-15.0-1                                                                      | No      | ----      | ----
+ 7 | repo-debug                          | openSUSE-Leap-15.0-Debug                                                                  | No      | ----      | ----
+ 8 | repo-debug-non-oss                  | openSUSE-Leap-15.0-Debug-Non-Oss                                                          | No      | ----      | ----
+ 9 | repo-debug-update                   | openSUSE-Leap-15.0-Update-Debug                                                           | No      | ----      | ----
+10 | repo-debug-update-non-oss           | openSUSE-Leap-15.0-Update-Debug-Non-Oss                                                   | No      | ----      | ----
+11 | repo-non-oss                        | openSUSE-Leap-15.0-Non-Oss                                                                | Yes     | (r ) Yes  | Yes
+12 | repo-oss                            | openSUSE-Leap-15.0-Oss                                                                    | Yes     | (r ) Yes  | Yes
+13 | repo-source                         | openSUSE-Leap-15.0-Source                                                                 | No      | ----      | ----
+14 | repo-source-non-oss                 | openSUSE-Leap-15.0-Source-Non-Oss                                                         | No      | ----      | ----
+15 | repo-update                         | openSUSE-Leap-15.0-Update                                                                 | Yes     | (r ) Yes  | Yes
+16 | repo-update-non-oss                 | openSUSE-Leap-15.0-Update-Non-Oss                                                         | Yes     | (r ) Yes  | Yes
+```
+
+### Example for Fedora distro
+
+```bash
+isv_LinuxAutomotive_AGL_FunkyFlounder       isv:LinuxAutomotive:AGL disabled
+isv_LinuxAutomotive_AGL_Master            Automotive Grade Linux  enabled
+```
+
+The following commands enable the "ElectricEel" repository:
+
+```bash
+dnf config-manager --set-disabled isv_LinuxAutomotive_AGL_Master
+dnf config-manager --set-enabled isv_LinuxAutomotive_AGL_FunkyFlounder
+```
+
+```bash
+$ dnf repolist --all | grep AGL
+isv_LinuxAutomotive_AGL_FunkyFlounder       isv:LinuxAutomotive:AGL enabled
+isv_LinuxAutomotive_AGL_Master            Automotive Grade Linux  disabled
+```

--- a/host-configuration/docs/3-installing-binder-daemon.md
+++ b/host-configuration/docs/3-installing-binder-daemon.md
@@ -1,0 +1,77 @@
+# 3. Installing the Binder Daemon
+
+The Application Framework Binder Daemon (`afb-daemon`), which is a part of
+the AGL Application Framework, provides a way to connect applications to
+required services.
+It provides a fast way to securely offer APIs to applications that are
+written in any language and that can run almost anywhere.
+
+You can learn more about the AGL Application Framework in the
+"[AGL Framework Overview](../../../../../../apis_services/en/dev/reference/af-main/0-introduction.html)"
+section.
+You can learn more about the `aft-daemon` in the
+"[Binder Overview](../../../../../../apis_services/en/dev/reference/af-binder/afb-overview.html)"
+section.
+
+## Installing on Debian
+
+Use the following commands if your native Linux machine uses the Debian
+distribution:
+
+```bash
+$ sudo apt-get install agl-app-framework-binder-dev
+```
+
+## Installing on OpenSUSE
+
+Use the following commands if your native Linux machine uses the OpenSUSE
+distribution:
+
+  ```bash
+  $ sudo zypper install agl-app-framework-binder-devel
+  ```
+
+## Installing on Fedora
+
+Use the following commands if your native Linux machine uses the Fedora
+distribution:
+
+  ```bash
+  $ sudo dnf install agl-app-framework-binder-devel
+  ```
+
+## Setting Your Environment Variables
+
+Regardless of your system's distribution, you need to set certain environment
+variables correctly in order to use the daemon (i.e. `app-framework-binder`).
+
+Commands that define and export these environment variables exist in the
+`/etc/profile.d/AGL_app-framework-binder.sh` file, which is created when
+you install the daemon:
+
+```bash
+export LD_LIBRARY_PATH=/opt/AGL/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}
+export LIBRARY_PATH=/opt/AGL/lib/x86_64-linux-gnu:${LIBRARY_PATH}
+export PKG_CONFIG_PATH=/opt/AGL/lib/x86_64-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}
+export PATH=/opt/AGL/bin:${PATH}
+```
+
+You can make sure thest environment variables are correctly set by doing
+one of the following:
+
+* **Logout and Log Back In:**
+
+  Logging out and then logging back in correctly sets the environment
+  variables.
+
+* **Manually Source the `AGL_app-framework-binder.sh` File:**
+
+  Source the following command:
+
+  ```bash
+  $ source /etc/profile.d/AGL_app-framework-binder.sh
+  ```
+
+  **NOTE:**
+  Creating a new session automatically sources the `AGL_app-framework-binder.sh`
+  file.

--- a/host-configuration/docs/4-getting-source-files.md
+++ b/host-configuration/docs/4-getting-source-files.md
@@ -1,0 +1,64 @@
+# 4. Getting Your Source Files
+
+Now that you have your host ready, packages installed, and the binder
+daemon ready, you can get your source files together.
+This example uses the `helloworld-service` binding, which is
+a project hosted on GitHub, is written in the C programming language,
+depends on the `libjson-c` library, and uses `cmake` for building.
+
+## Install Programs and Libraries You Need for this Example
+
+For this example, you need to have the following installed on your host:
+
+```
+git
+cmake
+gcc
+g++
+json-c
+```
+
+**NOTE:** If you are building a different binding, you need to make sure
+you have all the programs and libraries needed to build that particular
+binding.
+
+### Installing on Debian
+
+Use the following commands if your native Linux machine uses the Debian
+distribution:
+
+```bash
+sudo apt-get install git cmake gcc g++ libjson-c-dev
+```
+
+### Installing on OpenSUSE
+
+Use the following commands if your native Linux machine uses the OpenSUSE
+distribution:
+
+```bash
+sudo zypper install git cmake gcc gcc-c++ libjson-c-devel
+```
+
+### Installing on Fedora
+
+Use the following commands if your native Linux machine uses the Fedora
+distribution:
+
+```bash
+sudo dnf install git cmake gcc gcc-c++ json-c-devel.x86_64
+```
+
+## Cloning the helloworld-service repository
+
+Use Git to create a local repository of the
+[helloworld-service](https://github.com/iotbzh/helloworld-service) binding from
+[IoT.BZH](https://iot.bzh/en/).
+The following command creates a repository named `helloworld-service` in the
+current directory.
+The "--recurse-submodules" option ensures that all submodules (i.e. repositories
+within `helloworld-service`) are initialized and cloned as well.
+
+```bash
+git clone https://github.com/iotbzh/helloworld-service.git --recurse-submodules
+```

--- a/host-configuration/docs/5-building-and-running-service-natively.md
+++ b/host-configuration/docs/5-building-and-running-service-natively.md
@@ -1,0 +1,98 @@
+# 5. Building and Running Your Service Natively
+
+The next step in the binder development process is to build your
+binder and run it using your native Linux system.
+
+**NOTE:** This section assumes using the `helloworld-service` example
+and completion of the previous steps in this
+"[Building Microservices Natively](./0-build-microservice-overview.html)"
+section.
+
+## Building the Service
+
+Move to the cloned `helloworld-service` repository and build the service
+using either of the following methods:
+
+* ```bash
+  $ cd helloworld-service
+  $ ./conf.d/autobuild/linux/autobuild package
+  ```
+
+* ```bash
+  $ cd helloworld-service
+  $ mkdir build
+  $ cd build
+  $ cmake ..
+  $ make
+  ```
+
+## Running the Service
+
+You use the Application Framework Binder Daemon (`afb-daemon`) to
+bind one instance of an application or service to the rest of the system.
+In this example, you are binding an instance of `helloworld-service`
+to the rest of the system:
+
+```bash
+$ afb-daemon --binding helloworld.so --port 3333 --token ''
+```
+
+The previous command starts `afb-daemon` and loads the `helloworld.so`
+binding.
+The daemon is now listening on port 3333 of the `localhost`.
+
+## Using Optional Tools
+
+Once you have built and run your micro-service successfully using your 
+native Linux system, you should consider using some additional 
+development tools: X(Cross) Development System (XDS) and 
+the Controller Area Network (CAN) Development Studio (CANdevStudio).
+
+* **XDS:** Cross-compiles and ports your AGL image to your target hardware.
+For information on XDS, see the 
+"[XDS User's Guide](../../xds/part-1/0_Abstract.html)" 
+section.
+
+* **CANdevStudio:** Simulates CAN signals such as ignition status,
+doors status, or reverse gear by every automotive developer.
+For information on CANdevStudio, see the
+"[CANdevStudio Quickstart](../../../../../../apis_services/en/dev/reference/candevstudio/docs/1_Usage.html)"
+section.
+
+## Troubleshooting
+
+### systemd and/or libmicrohttpd
+
+If you encounter an error message similar to the following,
+you need to make some changes to your `cmake` file:
+
+```shell
+-- Checking for module 'libmicrohttpd>=0.9.60'
+--   No package 'libmicrohttpd' found
+CMake Error at /usr/share/cmake/Modules/FindPkgConfig.cmake:415 (message):
+  A required package was not found
+Call Stack (most recent call first):
+  /usr/share/cmake/Modules/FindPkgConfig.cmake:593 (_pkg_check_modules_internal)
+  conf.d/app-templates/cmake/cmake.d/01-build_options.cmake:92 (PKG_CHECK_MODULES)
+  conf.d/app-templates/cmake/common.cmake:77 (include)
+  conf.d/cmake/config.cmake:184 (include)
+  CMakeLists.txt:3 (include)
+```
+
+Open the `config.cmake` file located in `helloworld-service/conf.d/cmake/` directory
+and add a hash character (i.e. #) to the beginning of the "libsystemd>=222"
+and "libmicrohttpd>=0.9.60" strings.
+Following is an example of the edits:
+
+```CMake
+  set (PKG_REQUIRED_LIST
+    json-c
+    #libsystemd>=222
+    afb-daemon
+    #libmicrohttpd>=0.9.60
+  )
+```
+
+After making these changes, rebuild the service again as described in the
+"[Building the Service](./4-getting-source-files.html#building-the-service)"
+section previously on this page.

--- a/host-configuration/docs/devguides-book.yml
+++ b/host-configuration/docs/devguides-book.yml
@@ -2,21 +2,21 @@ type: books
 books:
 -
     id: host-configuration
-    title: Host Configuration
+    title: Building Microservices Natively
     description: Host Configuration documentation
     keywords:
     author: "IotBzh"
-    version: master
+    version: sandbox/scottrif29/scottdocs
     chapters:
-        - url: 0_Abstract.md
-          name: Abstract
-        - url: 1_Prerequisites.md
-          name: Prerequisites
-        - url: 2_AGL_Application_Framework.md
-          name: AGL Application Framework
-        - url: 3_Binding_Build_Example.md
-          name: Binding Build Example
-        - url: 4_AGL_XDS.md
-          name: AGL XDS
-        - url: 5_Candevstudio.md
-          name: CanDevStudio
+        - url: 0-build-microservice-overview.md
+          name: Overview
+        - url: 1-verify-build-host.md
+          name: 1. Verify Your Build Host
+        - url: 2-download-packages.md
+          name: 2. Download Packages
+        - url: 3-installing-binder-daemon.md
+          name: 3. Installing the Binder Daemon
+        - url: 4-getting-source-files.md
+          name: 4. Getting Your Source Files
+        - url: 5-building-and-running-service-natively.md
+          name: 5. Building and Running Your Service Natively


### PR DESCRIPTION
I am adding the six new files for this section, which was
formerly known as "Host Configuration" in the Developer
Guides area of the documentation.  The section is now called
"Building Microservices Natively".  All the files have
been completely rewritten and the PR is from my fork of
agl-documentation and the "sandbox/scottrif29/scottdocs"
branch for consistency.

Signed-off-by: Scott Rifenbark <srifenbark@gmail.com>