### PR TITLE
Build Microservices: Removed title numbers

### DIFF
--- a/host-configuration/docs/1-verify-build-host.md
+++ b/host-configuration/docs/1-verify-build-host.md
@@ -1,4 +1,4 @@
-# 1. Verify Your Build Host
+# Verify Your Build Host
 
 In order to build a Microservice binding natively, you need to be using a
 supported Linux distribution.

--- a/host-configuration/docs/2-download-packages.md
+++ b/host-configuration/docs/2-download-packages.md
@@ -1,4 +1,4 @@
-# 2. Download Packages
+# Download Packages
 
 Different repositories exist for different AGL releases.
 You need to download and install the packages based on your version

--- a/host-configuration/docs/3-installing-binder-daemon.md
+++ b/host-configuration/docs/3-installing-binder-daemon.md
@@ -1,4 +1,4 @@
-# 3. Installing the Binder Daemon
+# Installing the Binder Daemon
 
 The Application Framework Binder Daemon (`afb-daemon`), which is a part of
 the AGL Application Framework, provides a way to connect applications to

--- a/host-configuration/docs/4-getting-source-files.md
+++ b/host-configuration/docs/4-getting-source-files.md
@@ -1,4 +1,4 @@
-# 4. Getting Your Source Files
+# Getting Your Source Files
 
 Now that you have your host ready, packages installed, and the binder
 daemon ready, you can get your source files together.

--- a/host-configuration/docs/5-building-and-running-service-natively.md
+++ b/host-configuration/docs/5-building-and-running-service-natively.md
@@ -1,4 +1,4 @@
-# 5. Building and Running Your Service Natively
+# Building and Running Your Service Natively
 
 The next step in the binder development process is to build your
 binder and run it using your native Linux system.

--- a/host-configuration/docs/devguides-book.yml
+++ b/host-configuration/docs/devguides-book.yml
@@ -11,12 +11,12 @@ books:
         - url: 0-build-microservice-overview.md
           name: Overview
         - url: 1-verify-build-host.md
-          name: 1. Verify Your Build Host
+          name: Verify Your Build Host
         - url: 2-download-packages.md
-          name: 2. Download Packages
+          name: Download Packages
         - url: 3-installing-binder-daemon.md
-          name: 3. Installing the Binder Daemon
+          name: Installing the Binder Daemon
         - url: 4-getting-source-files.md
-          name: 4. Getting Your Source Files
+          name: Getting Your Source Files
         - url: 5-building-and-running-service-natively.md
-          name: 5. Building and Running Your Service Natively
+          name: Building and Running Your Service Natively


### PR DESCRIPTION
These changes take the numbers out of the content
pages and out of the navigation pane titles. I left the
file names with the numbers to keep links from breaking.
However, for the user, the numbers are best left off.
They are clunky.

Signed-off-by: Scott Rifenbark <srifenbark@gmail.com>